### PR TITLE
PHP isn't guaranteed to be at /usr/bin/.

### DIFF
--- a/get-shit-done
+++ b/get-shit-done
@@ -1,4 +1,4 @@
-#!/usr/bin/php
+#!/usr/bin/env php
 <?php
 
 if ( 1 == $argc ) {


### PR DESCRIPTION
It's usually a better idea to use env to give us the proper location of php, instead of assuming it's in one place.
