### PR TITLE
Get-shit-done not mac compatible

### DIFF
--- a/get-shit-done
+++ b/get-shit-done
@@ -1,4 +1,4 @@
-#!/usr/bin/php
+#!/usr/bin/env php
 <?php
 
 if ( 1 == $argc ) {

--- a/get-shit-done
+++ b/get-shit-done
@@ -5,7 +5,7 @@ if ( 1 == $argc ) {
 	exitWithError("usage: " . $argv[0] . " [work | play]");
 }
 
-$whoami = trim(strtolower(`whoami`));
+$whoami = trim(`whoami`);
 
 if ( 'root' != strtolower($whoami) ) {
 	exitWithError("Please run script as root.");

--- a/get-shit-done
+++ b/get-shit-done
@@ -23,7 +23,7 @@ $siteList = array(
 	'yelp.com', 'slashdot.com'
 );
 
-$restartNetworkingCommand = '/etc/init.d/networking restart';
+$restartNetworkingCommand = 'dscacheutil -flushcache';
 $hostsFile = '/etc/hosts';
 $startToken = '## start-gsd';
 $endToken = '## end-gsd';

--- a/get-shit-done
+++ b/get-shit-done
@@ -14,13 +14,13 @@ if ( 'root' != strtolower($whoami) ) {
 $siteList = array(
 	'reddit.com', 'forums.somethingawful.com', 'somethingawful.com',
 	'digg.com', 'break.com', 'news.ycombinator.com',
-	'infoq.com', 'bebo.com', 'twitter.com',
+	'infoq.com', 'bebo.com', 'twitter.com', '4chan.org', 'boards.4chan.org',
 	'facebook.com', 'blip.com', 'youtube.com',
 	'vimeo.com', 'delicious.com', 'flickr.com',
 	'friendster.com', 'hi5.com', 'linkedin.com',
 	'livejournal.com', 'meetup.com', 'myspace.com',
 	'plurk.com', 'stickam.com', 'stumbleupon.com',
-	'yelp.com', 'slashdot.com'
+	'yelp.com', 'slashdot.com', 'tinychan.org'
 );
 
 $restartNetworkingCommand = '/etc/init.d/networking restart';

--- a/get-shit-done
+++ b/get-shit-done
@@ -23,7 +23,11 @@ $siteList = array(
 	'yelp.com', 'slashdot.com'
 );
 
-$restartNetworkingCommand = 'dscacheutil -flushcache';
+$restartNetworkingCommand = '/etc/init.d/networking restart';
+$uname = `uname -a`;
+if (preg_match('/Darwin/', $uname))
+	$restartNetworkingCommand = 'dscacheutil -flushcache';
+
 $hostsFile = '/etc/hosts';
 $startToken = '## start-gsd';
 $endToken = '## end-gsd';


### PR DESCRIPTION
Added a line to check the uname -a and preg_match on /Darwin/ and use dscacheutil -flushcache (to flush local dns cache) 

Testing locally on a mac since this morning and works great for me.

--Steve
