### PR TITLE
Ini file support

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,11 @@ Execute it as root because it modifies your hosts file and restarts your network
 ### $siteList
 Add or remove elements of this array for sites to block or unblock.
 
+### ~/.get-shit-done.ini
+As an alternative to above, add lines in format
+$sites[] = www.blah.com
+to this file
+
 ### $restartNetworkingCommand
 Update this variable with the path to your network daemon along with any parameters needed to restart it.
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Add or remove elements of this array for sites to block or unblock.
 
 ### ~/.get-shit-done.ini
 As an alternative to above, add lines in format
-$sites[] = www.blah.com
+sites[] = www.blah.com
 to this file
 
 ### $restartNetworkingCommand

--- a/get-shit-done
+++ b/get-shit-done
@@ -11,17 +11,25 @@ if ( 'root' != strtolower($whoami) ) {
 	exitWithError("Please run script as root.");
 }
 
-$siteList = array(
-	'reddit.com', 'forums.somethingawful.com', 'somethingawful.com',
-	'digg.com', 'break.com', 'news.ycombinator.com',
-	'infoq.com', 'bebo.com', 'twitter.com',
-	'facebook.com', 'blip.com', 'youtube.com',
-	'vimeo.com', 'delicious.com', 'flickr.com',
-	'friendster.com', 'hi5.com', 'linkedin.com',
-	'livejournal.com', 'meetup.com', 'myspace.com',
-	'plurk.com', 'stickam.com', 'stumbleupon.com',
-	'yelp.com', 'slashdot.com'
-);
+$homedir = trim(`cd ~ && pwd`);
+$iniFile = $homedir.'/.get-shit-done.ini';
+
+if (file_exists($iniFile)) {
+	$iniContents = parse_ini_file($iniFile);
+	$siteList = $iniContents['sites'];
+} else {
+	$siteList = array(
+		'reddit.com', 'forums.somethingawful.com', 'somethingawful.com',
+		'digg.com', 'break.com', 'news.ycombinator.com',
+		'infoq.com', 'bebo.com', 'twitter.com',
+		'facebook.com', 'blip.com', 'youtube.com',
+		'vimeo.com', 'delicious.com', 'flickr.com',
+		'friendster.com', 'hi5.com', 'linkedin.com',
+		'livejournal.com', 'meetup.com', 'myspace.com',
+		'plurk.com', 'stickam.com', 'stumbleupon.com',
+		'yelp.com', 'slashdot.com'
+	);
+}
 
 $restartNetworkingCommand = '/etc/init.d/networking restart';
 $hostsFile = '/etc/hosts';


### PR DESCRIPTION
Added an optional ini file in ~/.get-shit-done.ini, and update documentation.

Needs to have the format

sites[] = www.blah.com

Ini file will override defaults provided in get-shit-done script
