### PR TITLE
Added plus.google.com and scripts sharing block list

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # get-shit-done
+
 get-shit-done is an easy to use command line program that blocks websites known to distract us from our work.
 
 After cloning this repository, put it in your $PATH and ensure it is executable.
@@ -6,28 +7,33 @@ After cloning this repository, put it in your $PATH and ensure it is executable.
 Execute it as root because it modifies your hosts file and restarts your network daemon.
 
 ## To get-shit-done
-`sudo get-shit-done work`
+
+    $ sudo get-shit-done work
 
 ## To no longer get-shit-done
-`sudo get-shit-done play`
+
+    $ sudo get-shit-done play
 
 ### $siteList
+
 Add or remove elements of this array for sites to block or unblock.
 
 ### ~/.get-shit-done.ini
-As an alternative to above, add lines in format
-sites[] = www.blah.com
-to this file
 
-If you are using the python script, the configuration file can contain list of comma-seperated sites as value to sites key. The duplicates will be removed, and www is prepended to eac
+Appends additional sites to block.  Duplicates will be removed, and www is prepended.
+
+    sites = foo.com, bar.com, baz.com
 
 ### $restartNetworkingCommand
+
 Update this variable with the path to your network daemon along with any parameters needed to restart it.
 
 ### $hostsFile
+
 Update this variable to point to the location of your hosts file. Make sure it is an absolute path.
 
 # Updates
+
 It's amazing how fast this repository has grown, I had never expected a single link on Hacker News would have caused that! I love it.
 
 I'd really love if anyone wanted to follow some of my other repositories, including [jolt](https://github.com/leftnode/jolt) or [dbmigrator](https://github.com/leftnode/dbmigrator). I think both are promising projects and I know I could use some help on them.

--- a/get-shit-done.php
+++ b/get-shit-done.php
@@ -27,7 +27,7 @@ if (file_exists($iniFile)) {
 		'friendster.com', 'hi5.com', 'linkedin.com',
 		'livejournal.com', 'meetup.com', 'myspace.com',
 		'plurk.com', 'stickam.com', 'stumbleupon.com',
-		'yelp.com', 'slashdot.org'
+		'yelp.com', 'slashdot.org', 'plus.google.com'
 	);
 }
 

--- a/get-shit-done.php
+++ b/get-shit-done.php
@@ -2,34 +2,17 @@
 <?php
 
 if ( 1 == $argc ) {
-	exitWithError("usage: " . $argv[0] . " [work | play]");
+  exitWithError("usage: " . $argv[0] . " [work | play]");
 }
 
 $whoami = trim(`whoami`);
-
 if ( 'root' != strtolower($whoami) ) {
-	exitWithError("Please run script as root.");
+  exitWithError("Please run script as root.");
 }
 
 $homedir = trim(`cd ~ && pwd`);
-$iniFile = $homedir.'/.get-shit-done.ini';
-
-if (file_exists($iniFile)) {
-	$iniContents = parse_ini_file($iniFile);
-	$siteList = $iniContents['sites'];
-} else {
-	$siteList = array(
-		'reddit.com', 'forums.somethingawful.com', 'somethingawful.com',
-		'digg.com', 'break.com', 'news.ycombinator.com',
-		'infoq.com', 'bebo.com', 'twitter.com',
-		'facebook.com', 'blip.com', 'youtube.com',
-		'vimeo.com', 'delicious.com', 'flickr.com',
-		'friendster.com', 'hi5.com', 'linkedin.com',
-		'livejournal.com', 'meetup.com', 'myspace.com',
-		'plurk.com', 'stickam.com', 'stumbleupon.com',
-		'yelp.com', 'slashdot.org', 'plus.google.com'
-	);
-}
+$iniLocal = $homedir.'/.get-shit-done.ini';
+$iniGlobal = './sites.ini';
 
 $uname = trim(`uname`);
 
@@ -47,59 +30,70 @@ if ( $uname == 'Linux' ) {
 $hostsFile = '/etc/hosts';
 $startToken = '## start-gsd';
 $endToken = '## end-gsd';
+$siteList = iniToArray($iniGlobal);
+
+if (file_exists($iniLocal)) {
+  $siteList = (array_merge($siteList, iniToArray($iniLocal)));
+}
 
 $action = $argv[1];
 
 switch ( $action ) {
-	case 'work': {
-		$contents = file_get_contents($hostsFile);
-		if($contents && strpos($contents, $startToken) !== false && strpos($contents, $endToken) !== false) {
-			exitWithError("Work mode already set.");        
-		}
-		
-		$fh = fopen($hostsFile, 'a');
-		if ( false === $fh ) {
-			exitWithError("Failed to open the hosts file.");
-		}
-		
-		fwrite($fh, $startToken . PHP_EOL);
-		foreach ( $siteList as $site ) {
-			fwrite($fh, "127.0.0.1\t{$site}" . PHP_EOL);
-			fwrite($fh, "127.0.0.1\twww.{$site}" . PHP_EOL);
-		}
-		fwrite($fh, $endToken . PHP_EOL);
-		
-		fclose($fh);
-		
-		shell_exec($restartNetworkingCommand);
-		
-		break;
-	}
-	
-	case 'play': {
-		$hostContents = file($hostsFile);
-		if ( false === $hostContents ) {
-			exitWithError("Failed to open the hosts file.");
-		}
-		
-		$startIndex = -1;
-		for ( $i=0; $i<count($hostContents); $i++ ) {
-			if ( trim($hostContents[$i]) == $startToken ) {
-				$startIndex = $i;
-			}
-		}
-		
-		if ( $startIndex > -1 ) {
-			$hostContents = array_slice($hostContents, 0, $startIndex);
-			file_put_contents($hostsFile, $hostContents);
-			shell_exec($restartNetworkingCommand);
-		}
-		
-		break;
-	}
+  case 'work': {
+    $contents = file_get_contents($hostsFile);
+    if($contents && strpos($contents, $startToken) !== false && strpos($contents, $endToken) !== false) {
+      exitWithError("Work mode already set.");
+    }
+
+    $fh = fopen($hostsFile, 'a');
+    if ( false === $fh ) {
+      exitWithError("Failed to open the hosts file.");
+    }
+
+    fwrite($fh, $startToken . PHP_EOL);
+    foreach ( $siteList as $site ) {
+      fwrite($fh, "127.0.0.1\t{$site}" . PHP_EOL);
+      fwrite($fh, "127.0.0.1\twww.{$site}" . PHP_EOL);
+    }
+    fwrite($fh, $endToken . PHP_EOL);
+
+    fclose($fh);
+
+    shell_exec($restartNetworkingCommand);
+
+    break;
+  }
+
+  case 'play': {
+    $hostContents = file($hostsFile);
+    if ( false === $hostContents ) {
+      exitWithError("Failed to open the hosts file.");
+    }
+
+    $startIndex = -1;
+    for ( $i=0; $i<count($hostContents); $i++ ) {
+      if ( trim($hostContents[$i]) == $startToken ) {
+        $startIndex = $i;
+      }
+    }
+
+    if ( $startIndex > -1 ) {
+      $hostContents = array_slice($hostContents, 0, $startIndex);
+      file_put_contents($hostsFile, $hostContents);
+      shell_exec($restartNetworkingCommand);
+    }
+
+    break;
+  }
 }
 
 function exitWithError($error) {
-	fwrite(STDERR, $error . PHP_EOL);
-	exit(1);
+  fwrite(STDERR, $error . PHP_EOL);
+  exit(1);
+}
+
+function iniToArray($iniFile) {
+  $iniContents = parse_ini_file($iniFile);
+
+  return explode(' ', $iniContents["sites"]);
 }

--- a/get-shit-done.py
+++ b/get-shit-done.py
@@ -32,7 +32,7 @@ site_list = ['reddit.com', 'forums.somethingawful.com', 'somethingawful.com',
             'youtube.com', 'vimeo.com', 'delicious.com', 'flickr.com',
             'friendster.com', 'hi5.com', 'linkedin.com', 'livejournal.com',
             'meetup.com', 'myspace.com', 'plurk.com', 'stickam.com',
-            'stumbleupon.com', 'yelp.com', 'slashdot.org']
+            'stumbleupon.com', 'yelp.com', 'slashdot.org', 'plus.google.com']
 
 def sites_from_ini(ini_file):
     # this enables the ini file to be written like

--- a/get-shit-done.py
+++ b/get-shit-done.py
@@ -10,8 +10,9 @@ from os import path
 def exit_error(error):
     print(error, file=sys.stderr)
     exit(1)
-    
-ini_file = path.expanduser(path.join("~", ".get-shit-done.ini"))
+
+ini_local = path.expanduser(path.join("~", ".get-shit-done.ini"))
+ini_global = './sites.ini'
 
 if "linux" in sys.platform:
     restart_network_command = ["/etc/init.d/networking", "restart"]
@@ -23,27 +24,25 @@ else:
     message = '"Please contribute DNS cache flush command on GitHub."'
     restart_network_command = ['echo', message]
 
-hosts_file = '/etc/hosts'
-start_token = '## start-gsd'
-end_token = '## end-gsd'
-site_list = ['reddit.com', 'forums.somethingawful.com', 'somethingawful.com',
-            'digg.com', 'break.com', 'news.ycombinator.com', 'infoq.com',
-            'bebo.com', 'twitter.com', 'facebook.com', 'blip.com',
-            'youtube.com', 'vimeo.com', 'delicious.com', 'flickr.com',
-            'friendster.com', 'hi5.com', 'linkedin.com', 'livejournal.com',
-            'meetup.com', 'myspace.com', 'plurk.com', 'stickam.com',
-            'stumbleupon.com', 'yelp.com', 'slashdot.org', 'plus.google.com']
-
-def sites_from_ini(ini_file):
+def ini_to_array(ini_file):
     # this enables the ini file to be written like
     # sites = google.com, facebook.com, quora.com ....
     if os.path.exists(ini_file):
-        ini_file_handle = open(ini_file)
-        for line in ini_file_handle:
+        f = open(ini_file)
+        sites = []
+        for line in f:
             key, value = [each.strip() for each in line.split("=", 1)]
             if key == "sites":
                 for item in [each.strip() for each in value.split(",")]:
-                    site_list.append(item)
+                    sites.append(item)
+        return sites
+    else:
+      return []
+
+hosts_file = '/etc/hosts'
+start_token = '## start-gsd'
+end_token = '## end-gsd'
+site_list = ini_to_array(ini_global) + ini_to_array(ini_local)
 
 def rehash():
     subprocess.check_call(restart_network_command)
@@ -93,5 +92,4 @@ def main():
     {"work": work, "play": play}[sys.argv[1]]()
 
 if __name__ == "__main__":
-    sites_from_ini(ini_file)
     main()

--- a/sites.ini
+++ b/sites.ini
@@ -1,0 +1,1 @@
+sites = reddit.com, forums.somethingawful.com, somethingawful.com, digg.com, break.com, news.ycombinator.com, infoq.com, bebo.com, twitter.com, facebook.com, blip.com, youtube.com, vimeo.com, delicious.com, flickr.com, friendster.com, hi5.com, linkedin.com, livejournal.com, meetup.com, myspace.com, plurk.com, stickam.com, stumbleupon.com, yelp.com, slashdot.org, plus.google.com


### PR DESCRIPTION
Added plus.google.com, and created a sites.ini which each script uses for blocks vs hardcoding in each.

The php script utilized ~/.get-shit-done.ini differently than the python script.  Updated php script to behave like the python script.

~/.get-shit-done.ini should be the following format, which is now standard across both scripts.

```
sites = foo.com, bar.com, baz.com
```

John
