### PR TITLE
Checking for start_token and end_token fails in python script

### DIFF
--- a/get-shit-done.py
+++ b/get-shit-done.py
@@ -48,7 +48,7 @@ def rehash():
     subprocess.check_call(restart_network_command)
 
 def work():
-    hFile = open(hosts_file, 'a+')
+    hFile = open(hosts_file, 'r+')
     contents = hFile.read()
 
     if start_token in contents and end_token in contents:


### PR DESCRIPTION
On Mac OS X using python 2.7.1,  run `sudo python get-shit-done.py work` several times. Note that the script doesn't exit with an error as expected on subsequent calls. Observe hosts file littered with multiple copies of blocked sites.

Have not confirmed on other systems.
