### PR TITLE
Remove commas from the end of URLs in PHP version

### DIFF
--- a/get-shit-done.php
+++ b/get-shit-done.php
@@ -95,5 +95,5 @@ function exitWithError($error) {
 function iniToArray($iniFile) {
   $iniContents = parse_ini_file($iniFile);
 
-  return explode(' ', $iniContents["sites"]);
+  return array_map('trim', explode(',', $iniContents["sites"]));
 }


### PR DESCRIPTION
PHP version splits by spaces, thus leaving commas at the end of URLs in the array. On Ubuntu /etc/hosts comma at the end of URL prevented from changing the host.

Splitting by comma and then trimming (just like in Python version), makes it work again.
