### PR TITLE
get-shit-done.sh: run correct Linux init script to restart networking

### DIFF
--- a/get-shit-done.sh
+++ b/get-shit-done.sh
@@ -162,7 +162,7 @@ curr_user=$(to_lower $curr_user)
 uname=$(trim `uname`)
 
 if [ "Linux" == $uname ]; then
-    restart_network="/etc/init.d/network restart"
+    restart_network="/etc/init.d/networking restart"
 elif [ "Darwin" == $uname ]; then
     restart_network="dscacheutil -flushcache"
 else


### PR DESCRIPTION
The file is /etc/init.d/networking and not /etc/init.d/network.
