### PR TITLE
make gsd work with symlinks

### DIFF
--- a/get-shit-done
+++ b/get-shit-done
@@ -1,7 +1,9 @@
 #!/bin/sh
 
 EXT=".php"
-DIRNAME=$(dirname $0)
+file="`readlink -f "$0"`"
+dir="`dirname "$file"`"
+DIRNAME="`readlink -f "$dir"`"
 
 if [ `whoami` != "root" ]
 then

--- a/get-shit-done.php
+++ b/get-shit-done.php
@@ -12,7 +12,7 @@ if ( 'root' != strtolower($whoami) ) {
 
 $homedir = trim(`cd ~ && pwd`);
 $iniLocal = $homedir.'/.get-shit-done.ini';
-$iniGlobal = './sites.ini';
+$iniGlobal = __DIR__ . '/sites.ini';
 
 $uname = trim(`uname`);
 


### PR DESCRIPTION
gsd currently fails when I symlink get-shit-done into `~/bin/`. This patches fix it.
