### PR TITLE
Use .config/get-shit-done.ini instead of ~/.get-shit-done.ini

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Execute it as root because it modifies your hosts file and restarts your network
 
 Add or remove elements of this array for sites to block or unblock.
 
-### ~/.get-shit-done.ini
+### ~/.config/get-shit-done.ini
 
 Appends additional sites to block.  Duplicates will be removed, and www is prepended.
 

--- a/get-shit-done.php
+++ b/get-shit-done.php
@@ -11,7 +11,7 @@ if ( 'root' != strtolower($whoami) ) {
 }
 
 $homedir = trim(`cd ~ && pwd`);
-$iniLocal = $homedir.'/.get-shit-done.ini';
+$iniLocal = $homedir.'/.config/get-shit-done.ini';
 $iniGlobal = __DIR__ . '/sites.ini';
 
 $uname = trim(`uname`);

--- a/get-shit-done.py
+++ b/get-shit-done.py
@@ -11,7 +11,7 @@ def exit_error(error):
     print(error, file=sys.stderr)
     exit(1)
 
-ini_local = path.expanduser(path.join("~", ".get-shit-done.ini"))
+ini_local = path.expanduser(path.join("~", ".config/get-shit-done.ini"))
 ini_global = './sites.ini'
 
 if "linux" in sys.platform:

--- a/get-shit-done.sh
+++ b/get-shit-done.sh
@@ -40,7 +40,7 @@ function work()
     # if no hosts file found...
     [ -e "$1" ] || exit_with_error $E_NO_HOSTS_FILE "No hosts file found"
 
-    ini_file="$HOME/.get-shit-done.ini"
+    ini_file="$HOME/.config/get-shit-done.ini"
 
     site_list=( 'reddit.com' 'forums.somethingawful.com' 'somethingawful.com'
 		'digg.com' 'break.com' 'news.ycombinator.com'


### PR DESCRIPTION
Since several years, `~/.config/` is the preferred location for configuration files. Using it stops cluttering your home directory.
