### PR TITLE
changed sed command to use -i

### DIFF
--- a/get-shit-done.sh
+++ b/get-shit-done.sh
@@ -109,7 +109,7 @@ d
 
     file=$1
 
-    sed --in-place -e "$sed_script" $file
+    sed -i -e "$sed_script" $file
 
     $restart_network
 }


### PR DESCRIPTION
On Mac OS Sierra 10.12.3, I was getting:

sed: illegal option -- -

When running get-shit-done play.

I've just replaced --in-place with -i to make it work again.