### PR TITLE
get-shit-done.sh: parse cmdline opts (-h,-i)

### DIFF
--- a/get-shit-done.sh
+++ b/get-shit-done.sh
@@ -1,5 +1,42 @@
 #!/bin/bash
 
+prgname_=`basename $0`
+
+print_help()
+{
+    cat <<EOF
+Usage: $prgname_ [-hv] [-i ini_file] {work | play}
+
+OPTIONS
+
+  -h|--help
+    Show this help text.
+  -i|--ini-file {file}
+    Path to the ini file containing the list of sites to block.
+EOF
+}
+
+options='hvi:'
+loptions='help,version,ini-file:'
+getopt_out=$(getopt --name $prgname_ --options $options --longoptions $loptions -- "$@")
+if (( $? != 0 )); then exit 1; fi
+eval set -- "$getopt_out"
+
+ini_file=
+while [[ $1 != "--" ]]; do
+    case "$1" in
+        -h|--help)
+            print_help
+            exit 0
+            ;;
+        -i|--ini-file)
+            ini_file=$2
+            shift 2
+            ;;
+    esac
+done
+shift
+
 E_NO_PARAMS=1
 E_USER_NOT_ROOT=2
 E_NO_HOSTS_FILE=3
@@ -26,13 +63,6 @@ to_lower()
     echo $1 | tr '[A-Z]' '[a-z]'
 }
 
-print_help()
-{
-    cat <<EOF
-Usage: `basename $0` [work | play]
-EOF
-}
-
 # just appends sites lines to the
 # end of first param file
 work()
@@ -40,7 +70,7 @@ work()
     # if no hosts file found...
     [ -e "$1" ] || exit_with_error $E_NO_HOSTS_FILE "No hosts file found"
 
-    ini_file="$HOME/.config/get-shit-done.ini"
+    ini_file=${ini_file:-"$HOME/.config/get-shit-done.ini"}
 
     site_list=( 'reddit.com' 'forums.somethingawful.com' 'somethingawful.com'
 		'digg.com' 'break.com' 'news.ycombinator.com'

--- a/get-shit-done.sh
+++ b/get-shit-done.sh
@@ -48,7 +48,7 @@ exit_with_error()
     # output to stderr
     echo $2 >&2
 
-    print_help
+    print_help >&2
 
     exit $1
 }
@@ -87,7 +87,7 @@ work()
     sites_from_ini $ini_file
 
     file="$1"
-    
+
     # check if work mode has been set
     if grep $start_token $file &> /dev/null; then
         if grep $end_token $file &> /dev/null; then
@@ -167,14 +167,14 @@ sites_from_ini()
             # get array size
             count=${#site_list[*]}
 
-            # add all sites to global sites array 
+            # add all sites to global sites array
             for site in $sites_arr
             do
                 site_list[$count]=$site
                 ((count++))
             done
         fi
-        
+
     done < "$1"
 }
 


### PR DESCRIPTION
This enables loading the ini file at any given location. The allowed options are:

- `- h`: help text.
- `- i`: the ini file path.

The `-h` text has been updated appropriately. This PR addresses #50.